### PR TITLE
Update guide instructions

### DIFF
--- a/pages/guides/next-js-tailwind.mdx
+++ b/pages/guides/next-js-tailwind.mdx
@@ -23,7 +23,7 @@ Here's a working version of what you'll end up creating:
 Run the following command to create a fresh project:
 
 ```bash
-npm create next-app next-js-tailwind
+npx create-next-app next-js-tailwind
 ```
 
 This command will make a new directory, add a `package.json` file with the necessary dependencies and script definitions, and scaffold a sample home page for you.

--- a/pages/guides/next-js-tailwind.mdx
+++ b/pages/guides/next-js-tailwind.mdx
@@ -23,7 +23,7 @@ Here's a working version of what you'll end up creating:
 Run the following command to create a fresh project:
 
 ```bash
-npx create-next-app next-js-tailwind
+npm init next-app next-js-tailwind
 ```
 
 This command will make a new directory, add a `package.json` file with the necessary dependencies and script definitions, and scaffold a sample home page for you.

--- a/pages/guides/next-landing-page.mdx
+++ b/pages/guides/next-landing-page.mdx
@@ -23,7 +23,7 @@ Here's a working version of what you'll end up creating:
 Run the following command to create a fresh project:
 
 ```bash
-npx create-next-app next-landing-page
+npm init next-app next-landing-page
 ```
 
 This command will make a new directory, add a `package.json` file with the necessary dependencies and script definitions, and scaffold a sample home page for you.

--- a/pages/guides/next-landing-page.mdx
+++ b/pages/guides/next-landing-page.mdx
@@ -23,7 +23,7 @@ Here's a working version of what you'll end up creating:
 Run the following command to create a fresh project:
 
 ```bash
-npm create next-app next-landing-page
+npx create-next-app next-landing-page
 ```
 
 This command will make a new directory, add a `package.json` file with the necessary dependencies and script definitions, and scaffold a sample home page for you.


### PR DESCRIPTION
Changed two things in the two guides installation instructions:

1. Previous command had `create next-app` when the package is `create-next-app` (missing hyphen).
2. Switched from `npm` to `npx` so that users won't need `create-next-app` installed locally before running.

Love the podcast, keep up the great work!